### PR TITLE
Avoid virtual calls to IPalettedBlockArray::set() in hot code paths

### DIFF
--- a/lib/BlockArrayContainer.h
+++ b/lib/BlockArrayContainer.h
@@ -105,7 +105,7 @@ public:
 	void specializeForArraySize(Visited& v) {
 #define TRY_CAST_TO(size) \
 		if (auto casted = dynamic_cast<PalettedBlockArray<size, Block>*>(blockArray)){ \
-			v.visit<size>(*casted); \
+			v.template visit<size>(*casted); \
 			return; \
 		}
 

--- a/lib/BlockArrayContainer.h
+++ b/lib/BlockArrayContainer.h
@@ -100,6 +100,27 @@ public:
 		delete blockArray;
 	}
 
+	// A godawful hack to avoid thousands of virtual calls during conversion and other things.
+	template<typename Visited>
+	void specializeForArraySize(Visited& v) {
+#define TRY_CAST_TO(size) \
+		if (auto casted = dynamic_cast<PalettedBlockArray<size, Block>*>(blockArray)){ \
+			v.visit<size>(*casted); \
+			return; \
+		}
+
+		TRY_CAST_TO(1)
+		TRY_CAST_TO(2)
+		TRY_CAST_TO(3)
+		TRY_CAST_TO(4)
+		TRY_CAST_TO(5)
+		TRY_CAST_TO(6)
+		TRY_CAST_TO(8)
+		TRY_CAST_TO(16)
+
+		v.visit(*blockArray);
+	}
+
 	const gsl::span<const char> getWordArray() const {
 		return blockArray->getWordArray();
 	}

--- a/lib/BlockArrayContainer.h
+++ b/lib/BlockArrayContainer.h
@@ -117,7 +117,7 @@ public:
 		TRY_CAST_TO(6)
 		TRY_CAST_TO(8)
 		TRY_CAST_TO(16)
-
+#undef TRY_CAST_TO
 		v.visit(*blockArray);
 	}
 

--- a/lib/BlockArrayContainer.h
+++ b/lib/BlockArrayContainer.h
@@ -101,12 +101,11 @@ public:
 	}
 
 	// A godawful hack to avoid thousands of virtual calls during conversion and other things.
-	template<typename Visited>
-	void specializeForArraySize(Visited& v) {
+	template<typename ReturnType, typename Visited>
+	ReturnType specializeForArraySize(Visited& v) {
 #define TRY_CAST_TO(size) \
 		if (auto casted = dynamic_cast<PalettedBlockArray<size, Block>*>(blockArray)){ \
-			v.template visit<size>(*casted); \
-			return; \
+			return v.template visit<size>(*casted); \
 		}
 
 		TRY_CAST_TO(1)

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -61,7 +61,7 @@ public:
 };
 
 template <uint8_t BITS_PER_BLOCK, typename Block>
-class PalettedBlockArray : public IPalettedBlockArray<Block> {
+class PalettedBlockArray final : public IPalettedBlockArray<Block> {
 private:
 	using Base = IPalettedBlockArray<Block>;
 	using Word = typename Base::Word;
@@ -187,7 +187,7 @@ public:
 		return palette[offset];
 	}
 
-	bool setNonVirtual(unsigned char x, unsigned char y, unsigned char z, Block val) {
+	bool set(unsigned char x, unsigned char y, unsigned char z, Block val) {
 		//TODO (suggested by sandertv): check performance when recording last written block and palette offset - might improve performance for repetetive writes
 
 		short offset = -1;
@@ -209,10 +209,6 @@ public:
 		_setPaletteOffset(x, y, z, offset);
 		this->mayNeedGC = true;
 		return true;
-	}
-
-	bool set(unsigned char x, unsigned char y, unsigned char z, Block val) {
-		return setNonVirtual(x, y, z, val);
 	}
 
 	unsigned short getPaletteOffset(unsigned char x, unsigned char y, unsigned char z) const {

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -187,7 +187,7 @@ public:
 		return palette[offset];
 	}
 
-	bool set(unsigned char x, unsigned char y, unsigned char z, Block val) {
+	bool setNonVirtual(unsigned char x, unsigned char y, unsigned char z, Block val) {
 		//TODO (suggested by sandertv): check performance when recording last written block and palette offset - might improve performance for repetetive writes
 
 		short offset = -1;
@@ -209,6 +209,10 @@ public:
 		_setPaletteOffset(x, y, z, offset);
 		this->mayNeedGC = true;
 		return true;
+	}
+
+	bool set(unsigned char x, unsigned char y, unsigned char z, Block val) {
+		return setNonVirtual(x, y, z, val);
 	}
 
 	unsigned short getPaletteOffset(unsigned char x, unsigned char y, unsigned char z) const {

--- a/lib/SubChunkConverter.h
+++ b/lib/SubChunkConverter.h
@@ -58,10 +58,10 @@ public:
 					uint8_t metaByte = metaArray[metaIdx];
 
 					swapCoordinates(x, y << 1, z, rX, rY, rZ);
-					blockArray.setNonVirtual(rX, rY, rZ, mapper(idArray[id1Idx], (metaByte & 0xf)));
+					blockArray.set(rX, rY, rZ, mapper(idArray[id1Idx], (metaByte & 0xf)));
 
 					swapCoordinates(x, (y << 1) | 1, z, rX, rY, rZ);
-					blockArray.setNonVirtual(rX, rY, rZ, mapper(idArray[id2Idx], ((metaByte >> 4) & 0xf)));
+					blockArray.set(rX, rY, rZ, mapper(idArray[id2Idx], ((metaByte >> 4) & 0xf)));
 				}
 			}
 		}

--- a/lib/SubChunkConverter.h
+++ b/lib/SubChunkConverter.h
@@ -110,7 +110,7 @@ static inline void convert(BlockArrayContainer<Block> * result, const gsl::span<
 	new(result) BlockArrayContainer<Block>(unique);
 
 	ConverterVisited<Block, getIndexArg, getIndex, mapper, swapCoordinates> converter(idArray, metaArray, extraArg);
-	result->specializeForArraySize(converter);
+	result->specializeForArraySize<void>(converter);
 	result->setGarbageCollected();
 }
 

--- a/lib/SubChunkConverter.h
+++ b/lib/SubChunkConverter.h
@@ -110,7 +110,7 @@ static inline void convert(BlockArrayContainer<Block> * result, const gsl::span<
 	new(result) BlockArrayContainer<Block>(unique);
 
 	ConverterVisited<Block, getIndexArg, getIndex, mapper, swapCoordinates> converter(idArray, metaArray, extraArg);
-	result->specializeForArraySize<void>(converter);
+	result->template specializeForArraySize<void>(converter);
 	result->setGarbageCollected();
 }
 


### PR DESCRIPTION
This godawful hack provides a 25% performance improvement to all SubChunkConverter methods.
It uses RTTI to decide the type of `PalettedBlockArray` at run-time so that the correct templated `ConverterVisited::visit()` can be called, which then calls `PalettedBlockArray::setNonVirtual()`. Since it's non-virtual, compilers happily inline it.