### PR TITLE
Significantly improve performance of PalettedBlockArray::validate()

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE("chunkutils2", "Enable PocketMine ChunkUtils2 extension", "no");
 
 if (PHP_CHUNKUTILS2 != "no") {
 	EXTENSION("chunkutils2", "chunkutils2.cpp", PHP_CHUNKUTILS2_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /permissive- /I" + configure_module_dirname + " /I" + configure_module_dirname + "/gsl/include /DGSL_THROW_ON_CONTRACT_VIOLATION=1");
-	ADD_FLAG("CFLAGS_CHUNKUTILS2", "/EHsc");
+	ADD_FLAG("CFLAGS_CHUNKUTILS2", "/EHsc /Qvec-report:1");
 	ADD_SOURCES(
 		configure_module_dirname + "/src",
 		"PhpLightArray.cpp PhpPalettedBlockArray.cpp PhpSubChunkConverter.cpp",

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -168,14 +168,14 @@ private:
 			if (BITS_PER_BLOCK_INT == 1) {
 				//For 1 bits-per-block, we can only reach this point if the palette isn't full, which means that only offset 0 is set.
 				//This means we can save a few instructions and just check the word directly for non-zero bits.
-				invalid |= word > 0;
+				invalid |= word;
 			} else {
 				Word carryVector = (~expected & word) | (~(expected ^ word) & (expected - word));
-				invalid |= carryVector > 0;
+				invalid |= carryVector;
 			}
 		}
 
-		if (invalid > 0) {
+		if (invalid != 0) {
 			//If we detected an error, use the old, slow method to locate the (first) source of errors
 			//this allows giving a detailed error message
 			//if the palette is valid, we can avoid this slow path entirely, which is the most likely outcome.

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -165,8 +165,14 @@ private:
 		for (auto wordIdx = 0; wordIdx < words.size(); wordIdx++) {
 			const auto word = words[wordIdx];
 
-			Word carryVector = (~expected & word) | (~(expected ^ word) & (expected - word));
-			invalid |= carryVector > 0;
+			if (BITS_PER_BLOCK_INT == 1) {
+				//For 1 bits-per-block, we can only reach this point if the palette isn't full, which means that only offset 0 is set.
+				//This means we can save a few instructions and just check the word directly for non-zero bits.
+				invalid |= word > 0;
+			} else {
+				Word carryVector = (~expected & word) | (~(expected ^ word) & (expected - word));
+				invalid |= carryVector > 0;
+			}
 		}
 
 		if (invalid > 0) {

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -144,6 +144,10 @@ private:
 		}
 	}
 
+#ifdef _MSC_VER
+	//If this function gets inlined, MSVC 16.29 does not want to vectorize it :(
+	__declspec(noinline)
+#endif
 	bool fastValidate() const {
 		Word invalid = 0;
 
@@ -155,7 +159,6 @@ private:
 		//Fast path - use carry-out vectors to detect invalid offsets
 		//This trick is borrowed from https://devblogs.microsoft.com/oldnewthing/20190301-00/?p=101076
 		//We can't detect exactly where the error is with this approach, but we leave that up to the slow code if we detect an error
-		//We put this in a separate function to make sure MSVC doesn't get scared out of vectorizing it
 		for (auto wordIdx = 0; wordIdx < words.size(); wordIdx++) {
 			const auto word = words[wordIdx];
 


### PR DESCRIPTION
This change introduces a fast path for validation using carry-out vectors, as discussed here: https://devblogs.microsoft.com/oldnewthing/20190301-00/?p=101076

TL;DR: It's possible to detect invalid palette offsets by subtracting the current "word" from a bitfield composed of the max valid palette offset, which is significantly faster than shifting and naively comparing each one.

In addition, we allow the code to chew through the whole loop even if invalid offsets are detected, in the hope that compilers will use SIMD instructions and/or parallelize the loop, which is also substantially faster than breaking out early on a branch condition to throw an exception.

The downside of the fast path is that it cannot report the exact offset an error occurred at, only that an error is present. For this reason, the old, slower code is retained, which allows generating detailed errors if an error is detected.

Note: This does cause a change of behaviour for palettes with padded words (3, 5, and 6 bits per block). The palette is now validated to be zero as a side effect of this change. If non-zero padding is found, the fast path will fail, and fallback to the slow path, which will ignore the error. We may want to explicitly ignore or force padding to be zero.