### PR TITLE
Vectorize large palette lookup

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -8,7 +8,7 @@ if test "$PHP_CHUNKUTILS2" != "no"; then
   PHP_REQUIRE_CXX()
 
   dnl the 6th parameter here is required for C++ shared extensions
-  PHP_NEW_EXTENSION(chunkutils2, chunkutils2.cpp src/PhpLightArray.cpp src/PhpPalettedBlockArray.cpp src/PhpSubChunkConverter.cpp, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -std=c++14 -fno-strict-aliasing -DGSL_THROW_ON_CONTRACT_VIOLATION=1, yes)
+  PHP_NEW_EXTENSION(chunkutils2, chunkutils2.cpp src/PhpLightArray.cpp src/PhpPalettedBlockArray.cpp src/PhpSubChunkConverter.cpp, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -std=c++14 -fno-strict-aliasing -ftree-vectorize -DGSL_THROW_ON_CONTRACT_VIOLATION=1, yes)
   PHP_SUBST(CHUNKUTILS2_SHARED_LIBADD)
   PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
   PHP_ADD_BUILD_DIR($ext_builddir/lib, 1)

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -273,9 +273,9 @@ public:
 private:
 	const size_t VECTORIZED_LOOKUP_CHUNK_SIZE = 32;
 
-	bool _vectorizedLookupOffset(Block val, short offset) const {
+	bool _vectorizedLookupOffset(Block val, int offset) const {
 		int result = 0;
-		for (auto i = 0; i < VECTORIZED_LOOKUP_CHUNK_SIZE; i++) {
+		for (int i = 0; i < VECTORIZED_LOOKUP_CHUNK_SIZE; i++) {
 			result |= palette[i + offset] == val;
 		}
 		return result != 0;

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -288,7 +288,7 @@ private:
 		//For large ones the cost is worth it because scalar search is slow due to early exit
 		//This tells us approximately where to find a block in the palette if it exists
 		if (MAX_PALETTE_SIZE >= VECTORIZED_LOOKUP_CHUNK_SIZE * 2) {
-			for (; offset < nextPaletteIndex; offset += VECTORIZED_LOOKUP_CHUNK_SIZE) {
+			for (; offset + VECTORIZED_LOOKUP_CHUNK_SIZE <= nextPaletteIndex; offset += VECTORIZED_LOOKUP_CHUNK_SIZE) {
 				if (_vectorizedLookupOffset(val, offset)) {
 					break;
 				}

--- a/lib/PalettedBlockArray.h
+++ b/lib/PalettedBlockArray.h
@@ -288,7 +288,7 @@ private:
 		//For large ones the cost is worth it because scalar search is slow due to early exit
 		//This tells us approximately where to find a block in the palette if it exists
 		if (MAX_PALETTE_SIZE >= VECTORIZED_LOOKUP_CHUNK_SIZE * 2) {
-			for (; offset < nextPaletteIndex; offset += CHUNK_SIZE) {
+			for (; offset < nextPaletteIndex; offset += VECTORIZED_LOOKUP_CHUNK_SIZE) {
 				if (_vectorizedLookupOffset(val, offset)) {
 					break;
 				}


### PR DESCRIPTION
This produces a substantial performance improvement for writing to 8 and 16 bpb palettes.

However, we should probably consider specializing 16 bpb considering that writes to it are 3 orders of magnitude slower than other palettes.

Simulated benchmark numbers using google/benchmark:
without vectorization
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
read<VanillaPaletteSize::BPB_0>         1100 ns         1100 ns       630154
read<VanillaPaletteSize::BPB_1>         2679 ns         2679 ns       260695
read<VanillaPaletteSize::BPB_2>         2681 ns         2681 ns       260555
read<VanillaPaletteSize::BPB_3>         3677 ns         3677 ns       188718
read<VanillaPaletteSize::BPB_4>         3132 ns         3132 ns       221270
read<VanillaPaletteSize::BPB_5>         3731 ns         3731 ns       186571
read<VanillaPaletteSize::BPB_6>         3768 ns         3768 ns       188250
read<VanillaPaletteSize::BPB_8>         2254 ns         2254 ns       309918
read<VanillaPaletteSize::BPB_16>        3133 ns         3133 ns       226425
write<VanillaPaletteSize::BPB_0>       0.000 ns        0.000 ns   1000000000000
write<VanillaPaletteSize::BPB_1>        6648 ns         6648 ns       104841
write<VanillaPaletteSize::BPB_2>        6426 ns         6426 ns       107461
write<VanillaPaletteSize::BPB_3>        9122 ns         9122 ns        76639
write<VanillaPaletteSize::BPB_4>       12126 ns        12126 ns        58056
write<VanillaPaletteSize::BPB_5>       22984 ns        22984 ns        30413
write<VanillaPaletteSize::BPB_6>       51880 ns        51879 ns        13488
write<VanillaPaletteSize::BPB_8>      213576 ns       213577 ns         3260
write<VanillaPaletteSize::BPB_16>    3082708 ns      3082720 ns          225
```
with vectorization
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
read<VanillaPaletteSize::BPB_0>         1091 ns         1091 ns       635347
read<VanillaPaletteSize::BPB_1>         2686 ns         2686 ns       261933
read<VanillaPaletteSize::BPB_2>         2700 ns         2699 ns       262246
read<VanillaPaletteSize::BPB_3>         3683 ns         3683 ns       191747
read<VanillaPaletteSize::BPB_4>         3088 ns         3088 ns       228623
read<VanillaPaletteSize::BPB_5>         3644 ns         3644 ns       190201
read<VanillaPaletteSize::BPB_6>         3655 ns         3655 ns       190197
read<VanillaPaletteSize::BPB_8>         2243 ns         2243 ns       310573
read<VanillaPaletteSize::BPB_16>        3048 ns         3048 ns       229392
write<VanillaPaletteSize::BPB_0>       0.000 ns        0.000 ns   1000000000000
write<VanillaPaletteSize::BPB_1>        6866 ns         6866 ns       101341
write<VanillaPaletteSize::BPB_2>        6746 ns         6746 ns       103729
write<VanillaPaletteSize::BPB_3>        9842 ns         9842 ns        71173
write<VanillaPaletteSize::BPB_4>       15082 ns        15082 ns        46566
write<VanillaPaletteSize::BPB_5>       27892 ns        27892 ns        25211
write<VanillaPaletteSize::BPB_6>       49537 ns        49538 ns        13291
write<VanillaPaletteSize::BPB_8>       97699 ns        97698 ns         7117
write<VanillaPaletteSize::BPB_16>     799022 ns       799019 ns          878
```